### PR TITLE
최종 수정

### DIFF
--- a/soloproject/src/components/contents.js
+++ b/soloproject/src/components/contents.js
@@ -5,7 +5,7 @@ import bookmarkOff from "../img/bookmarkOff.png";
 import { AppContext } from "../App";
 
 const Content = styled.div`
-  margin-top: 30px;
+  margin-top: 30px !important;
   margin: 0 5px;
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
최종 CSS 수정
질문)
모달창을 컴포넌트로 분리해서 각각의 페이지에서 불러오도록 코드를 만들었는데, 모달창을 열었을때 모달 뒤가 스크롤되는것을 막는 방법을 모르겠습니다. overflow = 'hidden'을 모달 뒤의 배경에 적용해도 작동하지 않았습니다.모달이 열리고 닫히는 상태를  useContext를 사용해서 최상위 컴포넌트에서 따로 관리해 컨트롤해야하나요?